### PR TITLE
Fix Mac lib path to take x86_64 architecture

### DIFF
--- a/Gems/Umbra/Code/Platform/Mac/PAL_mac.cmake
+++ b/Gems/Umbra/Code/Platform/Mac/PAL_mac.cmake
@@ -10,22 +10,22 @@ set(PAL_TRAIT_UMBRA_EDITOR_TEST_SUPPORTED FALSE)
 set(UMBRA_TARGET "3rdParty::umbra")
 
 set(UMBRA_LIBRARIES_DEBUG
-    ${UMBRA_SDK_PATH}/bin/macosx64/libumbraoptimizer64_d.dylib)
+    ${UMBRA_SDK_PATH}/bin/macosx/x86_64/libumbraoptimizer64_d.dylib)
 set(UMBRA_LIBRARIES_RELEASE
-    ${UMBRA_SDK_PATH}/bin/macosx64/libumbraoptimizer64.dylib)
+    ${UMBRA_SDK_PATH}/bin/macosx/x86_64/libumbraoptimizer64.dylib)
 set(UMBRA_STATIC_LIBRARIES_DEBUG
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraoptimizer_static64_d.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraobjectgrouper64_d.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraruntime64_d.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbracommon64_d.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbradpvs64_d.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraclusterpvs64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbratestdb64_d.a)
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraoptimizer_static64_d.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraobjectgrouper64_d.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraruntime64_d.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbracommon64_d.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbradpvs64_d.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraclusterpvs64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbratestdb64_d.a)
 set(UMBRA_STATIC_LIBRARIES_RELEASE
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraoptimizer_static64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraobjectgrouper64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraruntime64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbracommon64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbradpvs64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbraclusterpvs64.a
-    ${UMBRA_SDK_PATH}/lib/macosx64/libumbratestdb64.a)
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraoptimizer_static64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraobjectgrouper64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraruntime64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbracommon64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbradpvs64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbraclusterpvs64.a
+    ${UMBRA_SDK_PATH}/lib/macosx/x86_64/libumbratestdb64.a)


### PR DESCRIPTION

*Description of changes:*
- Add the ability for the Umbra gem to target x86_64 artifacts as O3DE uses that architecture for mac.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
