### PR TITLE
Fix SDKInit Memory Crash

### DIFF
--- a/Gems/AWSNativeSDKInit/Code/Include/AWSNativeSDKInit/AWSNativeSDKInitBus.h
+++ b/Gems/AWSNativeSDKInit/Code/Include/AWSNativeSDKInit/AWSNativeSDKInitBus.h
@@ -15,7 +15,7 @@ namespace AWSNativeSDKInit
         //! Call to guarantee that the API is initialized with proper Open 3D Engine settings.
         //! It's fine to call this from every module which needs to use the NativeSDK
         //! Creates a static shared pointer using the AZ EnvironmentVariable system.
-        //! This will prevent a the AWS SDK from going through the shutdown routine until all references are gone, or
+        //! This will prevent the AWS SDK from going through the shutdown routine until all references are gone, or
         //! the AZ::EnvironmentVariable system is brought down.
         virtual void InitAwsApi() = 0;
 

--- a/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.cpp
+++ b/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.cpp
@@ -12,6 +12,7 @@
 namespace AWSNativeSDKInit
 {
 #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+    AZ_CHILD_ALLOCATOR_WITH_NAME(AWSNativeSDKAllocator, "AWSNativeSDKAllocator", "{8B4DA42F-2507-4A5B-B13C-4B2A72BC161E}", AZ::SystemAllocator);
     const char* MemoryManager::AWS_API_ALLOC_TAG = "AwsApi";
 
     void MemoryManager::Begin() 
@@ -22,14 +23,14 @@ namespace AWSNativeSDKInit
     {
     }
 
-    void* MemoryManager::AllocateMemory(std::size_t blockSize, std::size_t alignment, const char* allocationTag) 
+    void* MemoryManager::AllocateMemory(std::size_t blockSize, std::size_t alignment, [[maybe_unused]]const char* allocationTag) 
     {
-        return m_allocator.Allocate(blockSize, alignment, 0, allocationTag);
+        return AZ::AllocatorInstance<AWSNativeSDKAllocator>::Get().allocate(blockSize, alignment);
     }
 
     void MemoryManager::FreeMemory(void* memoryPtr) 
     {
-        m_allocator.DeAllocate(memoryPtr);
+        AZ::AllocatorInstance<AWSNativeSDKAllocator>::Get().deallocate(memoryPtr);
     }
 #endif
 }

--- a/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.cpp
+++ b/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.cpp
@@ -12,6 +12,7 @@
 namespace AWSNativeSDKInit
 {
 #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+    AZ_CHILD_ALLOCATOR_WITH_NAME(AWSNativeSDKAllocator, "AWSNativeSDKAllocator", "{8B4DA42F-2507-4A5B-B13C-4B2A72BC161E}", AZ::SystemAllocator);
     const char* MemoryManager::AWS_API_ALLOC_TAG = "AwsApi";
 
     void MemoryManager::Begin() 
@@ -22,14 +23,14 @@ namespace AWSNativeSDKInit
     {
     }
 
-    void* MemoryManager::AllocateMemory(std::size_t blockSize, std::size_t alignment, const char* allocationTag) 
+    void* MemoryManager::AllocateMemory(std::size_t blockSize, std::size_t alignment, const char* /*allocationTag*/) 
     {
-        return m_allocator.Allocate(blockSize, alignment, 0, allocationTag);
+        return AZ::AllocatorInstance<AWSNativeSDKAllocator>::Get().allocate(blockSize, alignment);
     }
 
     void MemoryManager::FreeMemory(void* memoryPtr) 
     {
-        m_allocator.DeAllocate(memoryPtr);
+        AZ::AllocatorInstance<AWSNativeSDKAllocator>::Get().deallocate(memoryPtr);
     }
 #endif
 }

--- a/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.h
+++ b/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSMemoryInterface.h
@@ -20,8 +20,6 @@
 
 namespace AWSNativeSDKInit
 {
-    AZ_CHILD_ALLOCATOR_WITH_NAME(AWSNativeSDKAllocator, "AWSNativeSDKAllocator", "{8B4DA42F-2507-4A5B-B13C-4B2A72BC161E}", AZ::SystemAllocator);
-
 #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
     class MemoryManager : public Aws::Utils::Memory::MemorySystemInterface
     {
@@ -33,8 +31,6 @@ namespace AWSNativeSDKInit
 
         void* AllocateMemory(std::size_t blockSize, std::size_t alignment, const char* allocationTag = nullptr) override;
         void FreeMemory(void* memoryPtr) override;
-
-        AWSNativeSDKAllocator m_allocator;
     };
 #else
 

--- a/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSNativeSDKInitSystemComponent.cpp
+++ b/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSNativeSDKInitSystemComponent.cpp
@@ -100,15 +100,15 @@ namespace AWSNativeSDKInit
                 logLevel = Aws::Utils::Logging::LogLevel::Error;
             #endif
 
-            m_awsSDKOptions.loggingOptions.logLevel = logLevel;
-            m_awsSDKOptions.loggingOptions.logger_create_fn = [logLevel]()
+            m_awsSDKOptions.Get().loggingOptions.logLevel = logLevel;
+            m_awsSDKOptions.Get().loggingOptions.logger_create_fn = [logLevel]()
                 {
                     return Aws::MakeShared<AWSLogSystemInterface>("AWS", logLevel);
                 };
 
-            m_awsSDKOptions.memoryManagementOptions.memoryManager = &m_memoryManager;
-            Platform::CustomizeSDKOptions(m_awsSDKOptions);
-            Aws::InitAPI(m_awsSDKOptions);
+            m_awsSDKOptions.Get().memoryManagementOptions.memoryManager = &m_memoryManager;
+            Platform::CustomizeSDKOptions(m_awsSDKOptions.Get());
+            Aws::InitAPI(m_awsSDKOptions.Get());
         #endif // #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
 
         Platform::CopyCaCertBundle();
@@ -124,7 +124,7 @@ namespace AWSNativeSDKInit
     {
         m_initialized = false;
         #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
-            Aws::ShutdownAPI(m_awsSDKOptions);
+            Aws::ShutdownAPI(m_awsSDKOptions.Get());
             Platform::CustomizeShutdown();
         #endif
     }

--- a/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSNativeSDKInitSystemComponent.h
+++ b/Gems/AWSNativeSDKInit/Code/Source/Clients/AWSNativeSDKInitSystemComponent.h
@@ -55,10 +55,10 @@ namespace AWSNativeSDKInit
         ////////////////////////////////////////////////////////////////////////
 
     private:
-        MemoryManager m_memoryManager;
 
         #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
-            Aws::SDKOptions m_awsSDKOptions;
+            AWSNativeSDKInit::MemoryManager m_memoryManager;
+            AZ::EnvironmentVariable<Aws::SDKOptions> m_awsSDKOptions;
         #endif
 
 		bool m_initialized = false;


### PR DESCRIPTION
- Using singleton AZ::AllocatorInstance to grab memory manager instead of storing a class member variable allows AWS SDK to allocate memory without crashing.
- Storing AWSOptions in an environment-variable stops the crash caused when making a copying of the logging callback function.
Fixes #10 

Minor: Replacing deprecated Allocate() and DeAllocate() with the method it's already calling internally.